### PR TITLE
Add codemod to migrate to API established in v0.14

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,15 @@ module.exports = {
   },
   env: {
     'node': true,
+    'es6': true,
   },
   extends: 'eslint:recommended',
+  overrides: [
+    {
+      files: ['__tests__/**/*.js'],
+      env: {
+        jest: true
+      }
+    },
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -96,6 +96,32 @@ After:
 import { it } from 'mocha';
 ```
 
+### Testing API beginning in 0.14
+
+Changes your code to be compliant with the migration guide found [here](https://github.com/emberjs/ember-mocha/blob/master/docs/migration.md).
+
+The API beginning in 0.14 introduces many shared helpers and setup across the various types of Ember.js tests.  Formerly these types were called: `acceptance` for application wide concerns, `integration` for component tests (both rendering and user interaction), and finally `unit` tests for testing individual units at the lowest level.  In the newest API these have been reframed as `application` tests (formerly `acceptance`), `rendering` tests (formerly `integration`), and `unit` tests are largely unchanged.
+
+The majority of these changes are to unify test setup and helper usage.  A detailed list of the new helper APIs can be found [here](https://github.com/emberjs/ember-test-helpers/blob/master/API.md).
+
+This codemod will follow the migration guide to help you move your test suite from the style defined in 0.9 to the style defined in 0.14.
+
+It is important to review these changes, since there are many different configurations which this codemod attempts to reconcile with the new style you'll still need to review files after running this and make the necessary adjustments.  If you notice something that you feel the codemod should handle and doesn't please leave an issue with clearly defined inputs and outputs and an explanation of why you think it should handle this and we'll discuss resolutions.
+
+To begin this code mod:
+
+```
+jscodeshift -t https://raw.githubusercontent.com/Turbo87/ember-mocha-codemods/master/fourteen-testing-api.js PATH
+```
+
+This will do much of what you want, but notably does not handle many of the new helpers from `@ember/test-helpers` this is because there is another codemod that should also be run which can be found [here](https://github.com/simonihmig/ember-test-helpers-codemod).
+
+```
+cd my-ember-app-or-addon
+npx ember-test-helpers-codemod --type=integration tests/integration
+npx ember-test-helpers-codemod --type=acceptance tests/acceptance
+npx ember-test-helpers-codemod --type=native-dom tests
+```
 
 License
 ------------------------------------------------------------------------------

--- a/__testfixtures__/fourteen-testing-api/basic-application-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/basic-application-test.input.js
@@ -1,0 +1,25 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import startApp from 'app/tests/helpers/start-app';
+import destroyApp from 'app/tests/helpers/destroy-app';
+
+describe('basic acceptance test', function() {
+  let application;
+
+
+  beforeEach(function() {
+    application = startApp();
+  });
+
+  afterEach(function() {
+    destroyApp(application);
+  });
+
+  it('can visit /', function() {
+    visit('/');
+
+    andThen(() => {
+      expect(currentURL()).to.equal('/');
+    });
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/basic-application-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/basic-application-test.output.js
@@ -1,0 +1,13 @@
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import { setupApplicationTest } from 'ember-mocha';
+import { expect } from 'chai';
+
+describe('basic acceptance test', function() {
+  setupApplicationTest();
+
+  it('can visit /', async function() {
+    await visit('/');
+
+    expect(currentURL()).to.equal('/');
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/inject-calls.input.js
+++ b/__testfixtures__/fourteen-testing-api/inject-calls.input.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    integration: true
+  });
+
+
+  beforeEach(function() {
+    this.inject.service('serviceName', { as: 'cart' });
+  });
+
+  it('renders', function() {
+    expect(this.$('img')).to.exist;
+    this.render(hbs`{{gravatar-image foo=(action 'foo')}}`);
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/inject-calls.output.js
+++ b/__testfixtures__/fourteen-testing-api/inject-calls.output.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupRenderingTest();
+
+
+  beforeEach(function() {
+    this.cart = this.owner.lookup('service:serviceName');
+  });
+
+  it('renders', async function() {
+    expect(this.$('img')).to.exist;
+    await render(hbs`{{gravatar-image foo=(action 'foo')}}`);
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/on-call.input.js
+++ b/__testfixtures__/fourteen-testing-api/on-call.input.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    integration: true
+  });
+
+  this.on('bar', function() {});
+
+  this.on('foo', function() {});
+
+  beforeEach(function() {
+    this.render(hbs`{{gravatar-image foo=(action 'bar')}}`);
+  });
+
+  it('renders', function() {
+    expect(this.$('img')).to.exist;
+    this.render(hbs`{{gravatar-image foo=(action 'foo')}}`);
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/on-call.input.js
+++ b/__testfixtures__/fourteen-testing-api/on-call.input.js
@@ -9,11 +9,11 @@ describe('GravatarImageComponent', function() {
     integration: true
   });
 
-  this.on('bar', function() {});
-
-  this.on('foo', function() {});
-
   beforeEach(function() {
+    this.on('bar', function() {});
+
+    this.on('foo', function() {});
+
     this.render(hbs`{{gravatar-image foo=(action 'bar')}}`);
   });
 

--- a/__testfixtures__/fourteen-testing-api/on-call.output.js
+++ b/__testfixtures__/fourteen-testing-api/on-call.output.js
@@ -8,11 +8,11 @@ import hbs from 'htmlbars-inline-precompile';
 describe('GravatarImageComponent', function() {
   setupRenderingTest();
 
-  this.set('bar', function() {});
-
-  this.set('foo', function() {});
-
   beforeEach(async function() {
+    this.set('bar', function() {});
+
+    this.set('foo', function() {});
+
     await render(hbs`{{gravatar-image foo=(action bar)}}`);
   });
 

--- a/__testfixtures__/fourteen-testing-api/on-call.output.js
+++ b/__testfixtures__/fourteen-testing-api/on-call.output.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupRenderingTest();
+
+  this.set('bar', function() {});
+
+  this.set('foo', function() {});
+
+  beforeEach(async function() {
+    await render(hbs`{{gravatar-image foo=(action bar)}}`);
+  });
+
+  it('renders', async function() {
+    expect(this.$('img')).to.exist;
+    await render(hbs`{{gravatar-image foo=(action foo)}}`);
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/register-calls-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/register-calls-test.input.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    integration: true
+  });
+
+  beforeEach(function() {
+    this.render(hbs`{{gravatar-image}}`);
+    this.register('service:metrics', Service.extend({ trackEvent }));
+  });
+
+  it('renders', function() {
+    this.register('service:metrics', Service.extend({ trackEvent }));
+    expect(this.$('img')).to.exist;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/register-calls-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/register-calls-test.output.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupRenderingTest();
+
+  beforeEach(async function() {
+    await render(hbs`{{gravatar-image}}`);
+    this.owner.register('service:metrics', Service.extend({ trackEvent }));
+  });
+
+  it('renders', function() {
+    this.owner.register('service:metrics', Service.extend({ trackEvent }));
+    expect(this.$('img')).to.exist;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach } from 'mocha';
 import { setupComponentTest } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -10,6 +10,20 @@ describe('GravatarImageComponent', function() {
 
   it('renders', function() {
     this.render(hbs`{{gravatar-image}}`);
+    expect(this.$('img')).to.exist;
+  });
+});
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    integration: true
+  });
+
+  beforeEach(function() {
+    this.render(hbs`{{gravatar-image}}`);
+  });
+
+  it('renders', function() {
     expect(this.$('img')).to.exist;
   });
 });

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
@@ -12,6 +12,13 @@ describe('GravatarImageComponent', function() {
     this.render(hbs`{{gravatar-image}}`);
     expect(this.$('img')).to.exist;
   });
+
+  ['foo'].forEach(t => {
+    it('renders', function() {
+      this.render(hbs`{{gravatar-image}}`);
+      expect(this.$('img')).to.exist;
+    });
+  });
 });
 
 describe('GravatarImageComponent', function() {

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.input.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    integration: true
+  });
+
+  it('renders', function() {
+    this.render(hbs`{{gravatar-image}}`);
+    expect(this.$('img')).to.exist;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('GravatarImageComponent', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+    await render(hbs`{{gravatar-image}}`);
+    expect(this.$('img')).to.exist;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { describe, it, beforeEach } from 'mocha';
 import { setupRenderingTest } from 'ember-mocha';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -9,6 +9,18 @@ describe('GravatarImageComponent', function() {
 
   it('renders', async function() {
     await render(hbs`{{gravatar-image}}`);
+    expect(this.$('img')).to.exist;
+  });
+});
+
+describe('GravatarImageComponent', function() {
+  setupRenderingTest();
+
+  beforeEach(async function() {
+    await render(hbs`{{gravatar-image}}`);
+  });
+
+  it('renders', function() {
     expect(this.$('img')).to.exist;
   });
 });

--- a/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-component-test.output.js
@@ -11,6 +11,13 @@ describe('GravatarImageComponent', function() {
     await render(hbs`{{gravatar-image}}`);
     expect(this.$('img')).to.exist;
   });
+
+  ['foo'].forEach(t => {
+    it('renders', async function() {
+      await render(hbs`{{gravatar-image}}`);
+      expect(this.$('img')).to.exist;
+    });
+  });
 });
 
 describe('GravatarImageComponent', function() {

--- a/__testfixtures__/fourteen-testing-api/subject-usage.input.js
+++ b/__testfixtures__/fourteen-testing-api/subject-usage.input.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupComponentTest('gravatar-image', {
+    unit: true,
+    needs: []
+  });
+
+
+  it('renders', function() {
+    const subject = this.subject({
+      quantity: 1,
+      maxQuantity: 10
+    });
+
+    expect(subject.get('isMaxQuantity')).to.be.not.ok;
+  });
+});
+

--- a/__testfixtures__/fourteen-testing-api/subject-usage.output.js
+++ b/__testfixtures__/fourteen-testing-api/subject-usage.output.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+
+describe('GravatarImageComponent', function() {
+  setupTest();
+
+
+  it('renders', function() {
+    const subject = this.owner.factoryFor('component:gravatar-image').create({
+      quantity: 1,
+      maxQuantity: 10
+    });
+
+    expect(subject.get('isMaxQuantity')).to.be.not.ok;
+  });
+});

--- a/__tests__/fourteen-testing-api-test.js
+++ b/__tests__/fourteen-testing-api-test.js
@@ -1,0 +1,40 @@
+/* eslint-env: node */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const runInlineTest = require('jscodeshift/dist/testUtils').runInlineTest;
+const FourteenTestingAPITransform = require('../fourteen-testing-api');
+const fixtureFolder = `${__dirname}/../__testfixtures__/fourteen-testing-api`;
+
+describe('fourteen-testing-api', function() {
+  fs
+    .readdirSync(fixtureFolder)
+    .filter(filename => /\.input\.js$/.test(filename))
+    .forEach(filename => {
+      let testName = filename.replace('.input.js', '');
+      let inputPath = path.join(fixtureFolder, `${testName}.input.js`);
+      let outputPath = path.join(fixtureFolder, `${testName}.output.js`);
+
+      describe(testName, function() {
+        it('transforms correctly', function() {
+          runInlineTest(
+            FourteenTestingAPITransform,
+            {},
+            { source: fs.readFileSync(inputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+
+        it('is idempotent', function() {
+          runInlineTest(
+            FourteenTestingAPITransform,
+            {},
+            { source: fs.readFileSync(outputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+      });
+    });
+});

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -397,7 +397,9 @@ module.exports = function(file, api) {
             })
             .forEach(p => {
               let mod = new ModuleInfo(p);
-              emberMochaSpecifiers.add(mod.setupType);
+              if(mod.setupType) {
+                emberMochaSpecifiers.add(mod.setupType);
+              }
             });
         } else {
           emberMochaSpecifiers.add(mappedName);

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -143,6 +143,7 @@ module.exports = function(file, api) {
       this.isEmberMochaDescribe = false;
       this.tests = [];
       this.lifecycles = [];
+      this.body = p.node.expression.arguments[1].body;
       let describeBody = p.node.expression.arguments[1].body.body;
 
       describeBody.forEach(node => {
@@ -177,6 +178,13 @@ module.exports = function(file, api) {
           this.isEmberMochaDescribe = true;
           this.testVarDeclarationName = isAcceptanceTest.value.expression.left.name;
 
+          // Add setupApplicationTest to beginning of body
+          let exp = j.expressionStatement(
+            j.callExpression(j.identifier('setupApplicationTest'), [])
+          );
+          this.body.body[0] = exp;
+
+          // remove startApp invocation
           j(isAcceptanceTest).remove();
         }
 
@@ -672,11 +680,7 @@ module.exports = function(file, api) {
       .find(j.VariableDeclarator)
       .forEach(path => {
         if (path.node.id.name === name) {
-          let exp = j.expressionStatement(
-            j.callExpression(j.identifier('setupApplicationTest'), [])
-          );
-
-          path.parent.replace(exp);
+          path.parent.remove();
         }
       });
   }

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -182,7 +182,7 @@ module.exports = function(file, api) {
           let exp = j.expressionStatement(
             j.callExpression(j.identifier('setupApplicationTest'), [])
           );
-          this.body.body[0] = exp;
+          this.body.body =  [exp, ...this.body.body];
 
           // remove startApp invocation
           j(isAcceptanceTest).remove();
@@ -680,7 +680,7 @@ module.exports = function(file, api) {
       .find(j.VariableDeclarator)
       .forEach(path => {
         if (path.node.id.name === name) {
-          path.parent.remove();
+          j(path.parent).remove();
         }
       });
   }

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -63,6 +63,12 @@ module.exports = function(file, api) {
           this.isEmberMochaDescribe = true;
         }
 
+        let testPaths = j(node).find(j.ExpressionStatement, { expression: { callee: { name: 'it' } }}).paths();
+
+        if (testPaths.length > 0) {
+          testPaths.forEach(p => this.tests.push(p.value));
+        }
+
         if (j.match(node, { expression: { callee: { name: "it" } } })) {
           this.tests.push(node.expression);
         }

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -1,0 +1,234 @@
+'use strict';
+
+module.exports = function(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const SETUP_TYPE_METHODS = ["setupComponentTest"];
+
+  function isSetupTypeMethod(nodePath) {
+    return SETUP_TYPE_METHODS.some(name => {
+      let matcher = {
+        type: "ExpressionStatement",
+        expression: { callee: { name } }
+      };
+
+      return j.match(nodePath, matcher);
+    });
+  }
+
+  class ModuleInfo {
+    constructor(p) {
+      this.isEmberMochaDescribe = false;
+      this.tests = [];
+      let describeBody = p.node.expression.arguments[1].body.body;
+
+      describeBody.forEach(node => {
+        if (isSetupTypeMethod(node)) {
+          let options = node.expression.arguments[1];
+          this.hasIntegrationFlag = options.properties.some(p => p.key.name === "integration");
+          this.setupType = this.hasIntegrationFlag ? "setupRenderingTest" : "setupTest";
+          this.setupTypeMethodInvocationNode = node.expression;
+          this.isEmberMochaDescribe = true;
+        }
+
+        if (j.match(node, { expression: { callee: { name: "it" } } })) {
+          this.tests.push(node.expression);
+        }
+      });
+    }
+
+    updateSetupInvocation() {
+      this.setupTypeMethodInvocationNode.arguments = [];
+      this.setupTypeMethodInvocationNode.callee.name = this.setupType;
+    }
+
+    updateTests() {
+      this.tests.forEach((tExpression) => {
+        if(this.setupType === 'setupRenderingTest') {
+          processExpressionForRenderingTest(tExpression)
+        }
+      });
+    }
+  }
+
+  function findTestHelperUsageOf(collection, property) {
+    return collection.find(j.ExpressionStatement, {
+      expression: {
+        callee: {
+          object: {
+            type: "ThisExpression"
+          },
+          property: {
+            name: property
+          }
+        }
+      }
+    });
+  }
+
+  function processExpressionForRenderingTest(testExpression) {
+    // mark the test function as an async function
+    let testExpressionCollection = j(testExpression);
+    let specifiers = new Set();
+
+    // Transform to await render() or await clearRender()
+    ["render", "clearRender"].forEach(type => {
+      findTestHelperUsageOf(testExpressionCollection, type).forEach(p => {
+        specifiers.add(type);
+
+        let expression = p.get("expression");
+
+        let awaitExpression = j.awaitExpression(
+          j.callExpression(j.identifier(type), expression.node.arguments)
+        );
+        expression.replace(awaitExpression);
+        p.scope.node.async = true;
+      });
+    });
+
+    ensureImportWithSpecifiers({
+      source: "@ember/test-helpers",
+      anchor: "ember-mocha",
+      specifiers
+    });
+
+    // Migrate `this._element` -> `this.element`
+    testExpressionCollection
+      .find(j.MemberExpression, {
+        object: {
+          type: "ThisExpression"
+        },
+        property: {
+          name: "_element"
+        }
+      })
+      .forEach(p => {
+        let property = p.get("property");
+        property.node.name = "element";
+      });
+  }
+
+  function ensureImport(source, anchor, method) {
+    method = method || "insertAfter";
+
+    let desiredImport = root.find(j.ImportDeclaration, { source: { value: source } });
+    if (desiredImport.size() > 0) {
+      return desiredImport;
+    }
+
+    let newImport = j.importDeclaration([], j.literal(source));
+    let anchorImport = root.find(j.ImportDeclaration, { source: { value: anchor } });
+    let imports = root.find(j.ImportDeclaration);
+    if (anchorImport.size() > 0) {
+      anchorImport.at(anchorImport.size() - 1)[method](newImport);
+    } else if (imports.size() > 0) {
+      // if anchor is not present, always add at the end
+      imports.at(imports.size() - 1).insertAfter(newImport);
+    } else {
+      // if no imports are present, add as first statement
+      root.get().node.program.body.unshift(newImport);
+    }
+
+    return j(newImport);
+  }
+
+  function ensureImportWithSpecifiers(options) {
+    let source = options.source;
+    let specifiers = options.specifiers;
+    let anchor = options.anchor;
+    let positionMethod = options.positionMethod;
+
+    let importStatement = ensureImport(source, anchor, positionMethod);
+    let combinedSpecifiers = new Set(specifiers);
+
+    importStatement
+      .find(j.ImportSpecifier)
+      .forEach(i => combinedSpecifiers.add(i.node.imported.name))
+      .remove();
+
+    importStatement.get("specifiers").replace(
+      Array.from(combinedSpecifiers)
+      .sort()
+      .map(s => j.importSpecifier(j.identifier(s)))
+    );
+  }
+
+  function updateToNewEmberMochaImports() {
+    let mapping = {
+      setupComponentTest: "setupRenderingTest"
+    };
+
+    let emberMochaImports = root.find(j.ImportDeclaration, { source: { value: "ember-mocha" } });
+    if (emberMochaImports.size() === 0) {
+      return;
+    }
+
+    // Collect all imports from ember-mocha into local array
+    let emberMochaSpecifiers = new Set();
+
+    emberMochaImports
+      .find(j.ImportSpecifier)
+      .forEach(p => {
+        // Map them to the new imports
+        let importName = p.node.imported.name;
+        let mappedName = mapping[importName] || importName;
+
+        if (importName === "setupComponentTest") {
+          root
+            .find(j.ExpressionStatement, {
+              expression: {
+                callee: { name: "describe" }
+              }
+            })
+            .forEach(p => {
+              let mod = new ModuleInfo(p);
+              emberMochaSpecifiers.add(mod.setupType);
+            });
+        } else {
+          emberMochaSpecifiers.add(mappedName);
+        }
+      })
+    // Remove all existing import specifiers
+      .remove();
+
+    emberMochaImports
+      .get("specifiers")
+      .replace(Array.from(emberMochaSpecifiers).map(s => j.importSpecifier(j.identifier(s))));
+
+    // If we have an empty import, remove the import declaration
+    if (emberMochaSpecifiers.size === 0) {
+      emberMochaImports.remove();
+    }
+  }
+
+  function processDescribeBlock() {
+    let describes = root.find(j.ExpressionStatement, {
+      expression: {
+        callee: { name: "describe" }
+      }
+    });
+
+    if (describes.length === 0) {
+      return;
+    }
+
+    describes.forEach(p => {
+      let mod = new ModuleInfo(p);
+      if (!mod.isEmberMochaDescribe) {
+        return;
+      }
+
+      mod.updateSetupInvocation();
+
+      mod.updateTests();
+    });
+  }
+
+  const printOptions = { quote: "single", wrapColumn: 100 };
+
+  updateToNewEmberMochaImports();
+  processDescribeBlock();
+
+  return root.toSource(printOptions);
+}


### PR DESCRIPTION
Initial step completed here is to translate a simple rendering test (from migration guide).

Initial implementation came from ember-qunit codemod.  Almost all of the remaining work has corollaries there from which we'll be pulling.

TODO:

- [x] process Life Cycle Hooks (i.e. 'beforeEach', 'afterEach')
- [x] process `this.register`
- [x] process `this.on`
- [x] ~process `this.$`~
- [x] process `this.inject`
- [ ] ~process `this.lookup`~ ??
- [x] process `this.subject`
- [x] Acceptance Test -> Application Test
- [ ] Model Tests ??