### PR TITLE
transform route and controller tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+insert_final_newline = false
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/__testfixtures__/fourteen-testing-api/setup-controller-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-controller-test.input.js
@@ -1,0 +1,26 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Unit | Controller | state ruler', function() {
+  setupTest('controller:state-ruler', {
+    needs: [
+      'controller:application',
+      'controller:login',
+      'service:foo',
+      'service:bar',
+      'service:something'
+    ]
+  });
+
+  let controller;
+  beforeEach(function() {
+    controller = this.subject();
+  });
+
+  it('exists', function() {
+    controller.should.be.ok();
+  });
+
+});
+

--- a/__testfixtures__/fourteen-testing-api/setup-controller-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-controller-test.output.js
@@ -1,0 +1,18 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Unit | Controller | state ruler', function() {
+  setupTest();
+
+  let controller;
+  beforeEach(function() {
+    controller = this.owner.lookup('controller:state-ruler');
+  });
+
+  it('exists', function() {
+    controller.should.be.ok();
+  });
+
+});
+

--- a/__testfixtures__/fourteen-testing-api/setup-route-empty-needs-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-route-empty-needs-test.input.js
@@ -1,0 +1,22 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('LoadingIndexRoute', function() {
+  setupTest('route:loading/index', {
+    // needs: ['service:ajax']
+  });
+
+  describe('something', function() {
+
+    let route;
+    beforeEach(function() {
+      route = this.subject();
+    });
+
+    it('exists', function() {
+      route.should.be.ok();
+    });
+
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-route-empty-needs-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-route-empty-needs-test.output.js
@@ -1,0 +1,20 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('LoadingIndexRoute', function() {
+  setupTest();
+
+  describe('something', function() {
+
+    let route;
+    beforeEach(function() {
+      route = this.owner.lookup('route:loading/index');
+    });
+
+    it('exists', function() {
+      route.should.be.ok();
+    });
+
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-route-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-route-test.input.js
@@ -1,0 +1,14 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('LoadingIndexRoute', function() {
+  setupTest('route:loading/index', {
+    needs: ['service:ajax', 'service:data-store', 'service:foo']
+  });
+
+  it('exists', function() {
+    let route = this.subject();
+    route.should.be.ok();
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-route-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-route-test.output.js
@@ -1,0 +1,12 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('LoadingIndexRoute', function() {
+  setupTest();
+
+  it('exists', function() {
+    let route = this.owner.lookup('route:loading/index');
+    route.should.be.ok();
+  });
+});


### PR DESCRIPTION
fix #69. Also fixes a bug with nested lifecycle hooks causing `subjectContainerKey` to be undefined.
I tested these transforms against our application running  ember-mocha@0.14. The transform work, but I am seeing a bunch of errors I can detail elsewhere.