### PR TITLE
migrate setupModelTest to setupTest

### DIFF
--- a/__testfixtures__/fourteen-testing-api/setup-model-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-model-test.input.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupModelTest } from 'ember-mocha';
+
+describe('Unit | Model | rental', function() {
+  setupModelTest('rental', {
+    needs: []
+  });
+  // Replace this with your real tests.
+  it('exists', function() {
+    let model = this.subject();
+    expect(model).to.be.ok;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-model-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-model-test.output.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Model | rental', function() {
+  setupTest();
+  // Replace this with your real tests.
+  it('exists', function() {
+    let model = this.owner.lookup('service:store').createRecord('rental', {});
+    expect(model).to.be.ok;
+  });
+});

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -4,7 +4,7 @@ module.exports = function(file, api) {
   const j = api.jscodeshift;
   const root = j(file.source);
 
-  const SETUP_TYPE_METHODS = ["setupComponentTest"];
+  const SETUP_TYPE_METHODS = ["setupComponentTest", "setupModelTest"];
 
   function isSetupTypeMethod(nodePath) {
     return SETUP_TYPE_METHODS.some(name => {
@@ -193,6 +193,9 @@ module.exports = function(file, api) {
               this.setupType = "setupTest";
               this.subjectContainerKey = j.literal(`component:${node.expression.arguments[0].value}`);
             }
+          } else if (calleeName === 'setupModelTest') {
+            this.setupType = 'setupTest';
+            this.modelName = node.expression.arguments[0].value;
           }
 
           this.setupTypeMethodInvocationNode = node.expression;
@@ -459,9 +462,16 @@ module.exports = function(file, api) {
 
     thisDotSubjectUsage.forEach(p => {
       let options = p.node.arguments[0];
-      let split = subject.value.split(':');
-      let subjectType = split[0];
-      let subjectName = split[1];
+      let subjectType;
+      let subjectName;
+      if ('modelName' in moduleInfo) {
+        subjectType = 'model';
+        subjectName = moduleInfo.modelName;
+      } else {
+        let split = subject.value.split(':');
+        subjectType = split[0];
+        subjectName = split[1];
+      }
       let isSingletonSubject = ['model', 'component'].indexOf(subjectType) === -1;
 
       // if we don't have `options` and the type is a singleton type
@@ -477,15 +487,7 @@ module.exports = function(file, api) {
           )
         );
       } else if (subjectType === 'model') {
-        ensureImportWithSpecifiers({
-          source: '@ember/runloop',
-          specifiers: ['run'],
-        });
-
         p.replace(
-          j.callExpression(j.identifier('run'), [
-            j.arrowFunctionExpression(
-              [],
               j.callExpression(
                 j.memberExpression(
                   j.callExpression(
@@ -497,11 +499,10 @@ module.exports = function(file, api) {
                   ),
                   j.identifier('createRecord')
                 ),
-                [j.literal(subjectName), options].filter(Boolean)
-              ),
-              true
-            ),
-          ])
+                // creating an empty object expression {} as the 2nd argument here
+                // because setupModelTests shouldn't need store dependencies
+                [j.literal(subjectName), j.objectExpression([])].filter(Boolean)
+              )
         );
       } else {
         p.replace(
@@ -631,7 +632,8 @@ module.exports = function(file, api) {
 
   function updateToNewEmberMochaImports() {
     let mapping = {
-      setupComponentTest: "setupRenderingTest"
+      setupComponentTest: "setupRenderingTest",
+      setupModelTest: "setupTest"
     };
 
     let emberMochaImports = root.find(j.ImportDeclaration, { source: { value: "ember-mocha" } });


### PR DESCRIPTION
This migrates  `setupModelTests` to what the 0.15.x blueprints generates for ember-data models. I don't think the earlier version of the logic responsible for migrating model tests was executing on some test suites or ever executed. It generated something like (presuming the run import and store variable assignment):
```js
    let model = run(() => store.createRecord('rental'));
```
~~I have also manually tested this on our application's models and it looks as expected.~~
12% of our model unit tests were not migrated. I'm looking into those outliers and will update the PR accordingly.
@rondale-sc mind reviewing again? Thanks!