### PR TITLE
migrate tests for other entities

### DIFF
--- a/__testfixtures__/fourteen-testing-api/setup-adapter-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-adapter-test.input.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | rental', function() {
+  setupTest('adapter:rental', {
+    needs: ['service:store']
+  });
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let adapter = this.subject();
+    expect(adapter).to.be.ok;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-adapter-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-adapter-test.output.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapter | rental', function() {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let adapter = this.owner.lookup('adapter:rental');
+    expect(adapter).to.be.ok;
+  });
+});

--- a/__testfixtures__/fourteen-testing-api/setup-serializer-test.input.js
+++ b/__testfixtures__/fourteen-testing-api/setup-serializer-test.input.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Serializer | rental', function() {
+  setupTest('serializer:rental', {
+    needs: ['service:store']
+  });
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let serializer = this.subject();
+
+    expect(serializer).to.be.ok;
+  });
+
+});

--- a/__testfixtures__/fourteen-testing-api/setup-serializer-test.output.js
+++ b/__testfixtures__/fourteen-testing-api/setup-serializer-test.output.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Serializer | rental', function() {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let serializer = this.owner.lookup('service:store').serializerFor('rental');
+
+    expect(serializer).to.be.ok;
+  });
+
+});

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -54,8 +54,7 @@ module.exports = function(file, api) {
       && nodePath.expression.arguments.length === 2
       && j.Literal.check(nodePath.expression.arguments[0])
       && (
-        nodePath.expression.arguments[0].value.startsWith('route:')
-        || nodePath.expression.arguments[0].value.startsWith('controller:')
+        /^(adapter|route|controller|service|serializer):/.test(nodePath.expression.arguments[0].value)
       )
     return isSetupNeeds ;
   }

--- a/fourteen-testing-api.js
+++ b/fourteen-testing-api.js
@@ -54,7 +54,7 @@ module.exports = function(file, api) {
       && nodePath.expression.arguments.length === 2
       && j.Literal.check(nodePath.expression.arguments[0])
       && (
-        /^(adapter|route|controller|service|serializer):/.test(nodePath.expression.arguments[0].value)
+        /^(adapter|controller|route|service|serializer|transform):/.test(nodePath.expression.arguments[0].value)
       )
     return isSetupNeeds ;
   }
@@ -471,7 +471,7 @@ module.exports = function(file, api) {
         subjectType = split[0];
         subjectName = split[1];
       }
-      let isSingletonSubject = ['model', 'component'].indexOf(subjectType) === -1;
+      let isSingletonSubject = !['model', 'component', 'serializer'].includes(subjectType);
 
       // if we don't have `options` and the type is a singleton type
       // use `this.owner.lookup(subject)`
@@ -484,6 +484,22 @@ module.exports = function(file, api) {
             ),
             [subject]
           )
+        );
+      } else if (subjectType === 'serializer') {
+        p.replace(
+              j.callExpression(
+                j.memberExpression(
+                  j.callExpression(
+                    j.memberExpression(
+                      j.memberExpression(j.thisExpression(), j.identifier('owner')),
+                      j.identifier('lookup')
+                    ),
+                    [j.literal('service:store')]
+                  ),
+                  j.identifier('serializerFor')
+                ),
+                [j.literal(subjectName)].filter(Boolean)
+              )
         );
       } else if (subjectType === 'model') {
         p.replace(


### PR DESCRIPTION
Add support for migrating other core and ember-data entities. (https://github.com/Turbo87/ember-mocha-codemods/compare/master...efx:auxillary-refactors?expand=1#diff-8f8d3dcef7aff7b6288b886aa3cbb017R57)